### PR TITLE
Serverfixes3

### DIFF
--- a/server/test/db.helper.spec.js
+++ b/server/test/db.helper.spec.js
@@ -5,7 +5,13 @@ const dbhelper = require('../../db/helpers.js');
 
 describe('User', () => {
   beforeEach(function (done) {
-    knex('knex_migrations_lock').where('is_locked', '1').del()
+    knex.schema.hasTable('knex_migrations_lock')
+      .then((exists) => {
+        if (exists) {
+          return knex('knex_migrations_lock').where('is_locked', '1').del();
+        }
+        return;
+      })
       .then(() => {
         dbUtils.rollbackMigrate(done);
       });
@@ -13,7 +19,13 @@ describe('User', () => {
 
   // Resets database back to original settings
   afterEach(function (done) {
-    knex('knex_migrations_lock').where('is_locked', '1').del()
+    knex.schema.hasTable('knex_migrations_lock')
+      .then((exists) => {
+        if (exists) {
+          return knex('knex_migrations_lock').where('is_locked', '1').del();
+        }
+        return;
+      })
       .then(() => {
         dbUtils.rollback(done);
       });

--- a/server/test/profileModel.spec.js
+++ b/server/test/profileModel.spec.js
@@ -6,7 +6,13 @@ const knex = require('knex')(require('../../knexfile'));
 describe('User model tests', function () {
   // Deletes all tables, creates new tables, and seeds tables with test data
   beforeEach(function (done) {
-    knex('knex_migrations_lock').where('is_locked', '1').del()
+    knex.schema.hasTable('knex_migrations_lock')
+      .then((exists) => {
+        if (exists) {
+          return knex('knex_migrations_lock').where('is_locked', '1').del();
+        }
+        return;
+      })
       .then(() => {
         dbUtils.rollbackMigrate(done);
       });
@@ -14,7 +20,13 @@ describe('User model tests', function () {
 
   // Resets database back to original settings
   afterEach(function (done) {
-    knex('knex_migrations_lock').where('is_locked', '1').del()
+    knex.schema.hasTable('knex_migrations_lock')
+      .then((exists) => {
+        if (exists) {
+          return knex('knex_migrations_lock').where('is_locked', '1').del();
+        }
+        return;
+      })
       .then(() => {
         dbUtils.rollback(done);
       });
@@ -38,13 +50,13 @@ describe('User model tests', function () {
         expect(result.get('id')).to.equal(1);
       })
       .then(function () {
-        return User.where({ id: 1 }).save({ github_handle: 'James'}, { method: 'update' });
+        return User.where({ id: 1 }).save({ email: 'James@gmail.com'}, { method: 'update' });
       })
       .then(function () {
         return User.where({ id: 1 }).fetch();
       })
       .then(function (result) {
-        expect(result.get('github_handle')).to.equal('James');
+        expect(result.get('email')).to.equal('James@gmail.com');
         done();
       })
       .catch(function (err) {

--- a/server/test/server.apicrud.spec.js
+++ b/server/test/server.apicrud.spec.js
@@ -1147,9 +1147,8 @@ describe('CRUD API tickets', function () {
         expect(res.status).to.equal(200);
         expect(res.body.length).to.equal(3);
         expect(res.body[0].title).to.equal('testticket3C'); //priority 3, in progress
-        expect(res.body[1].title).to.equal('newticketname');
-        expect(res.body[2].title).to.equal('testticket3B'); //priority 2, in progress
-        expect(res.body[3].title).to.equal('testticket3A'); //priority 2, complete
+        expect(res.body[1].title).to.equal('newticketname'); //priority 2, in progress
+        expect(res.body[2].title).to.equal('testticket3A'); //priority 2, complete
         done();
       })
       .catch((err) => {

--- a/server/test/server.apicrud.spec.js
+++ b/server/test/server.apicrud.spec.js
@@ -12,7 +12,13 @@ describe('CRUD API authorization', function () {
   beforeEach(function (done) {
     authenticated = request(app);
     agent = request.agent(app);
-    knex('knex_migrations_lock').where('is_locked', '1').del()
+    knex.schema.hasTable('knex_migrations_lock')
+      .then((exists) => {
+        if (exists) {
+          return knex('knex_migrations_lock').where('is_locked', '1').del();
+        }
+        return;
+      })
       .then(() => {
         dbUtils.rollbackMigrate(done);
       });
@@ -20,7 +26,13 @@ describe('CRUD API authorization', function () {
 
   // Resets database back to original settings
   afterEach(function (done) {
-    knex('knex_migrations_lock').where('is_locked', '1').del()
+    knex.schema.hasTable('knex_migrations_lock')
+      .then((exists) => {
+        if (exists) {
+          return knex('knex_migrations_lock').where('is_locked', '1').del();
+        }
+        return;
+      })
       .then(() => {
         dbUtils.rollback(done);
       });
@@ -991,6 +1003,37 @@ describe('CRUD API tickets', function () {
       });
   });
 
+  it('rejects POST requests to /api/tickets to create ticket with assignee that isnt member of board', function(done) {
+    agent.get('/auth/fake3')
+      .then((res) => {
+        return agent.post('/api/tickets')
+          .send({
+            title: 'newticket',
+            description: 'newticket',
+            status: 'in progress',
+            priority: '1',
+            type: 'feature',
+            creator_id: 3,
+            assignee_handle: 'stevepkuo',
+            board_id: 3,
+            panel_id: 3
+          });
+      })
+      .then((res) => {
+        expect(res.status).to.equal(500);
+        return agent.get('/api/tickets')
+          .query({panel_id: 3});
+      })
+      .then((res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body.length).to.equal(3);
+        done();
+      })
+      .catch((err) => {
+        return done(err);
+      });
+  });
+
   it('rejects POST requests to /api/tickets to create duplicate ticket in a board that user is member of', function(done) {
     agent.get('/auth/fake3')
       .then((res) => {
@@ -1055,6 +1098,38 @@ describe('CRUD API tickets', function () {
       .then((res) => {
         expect(res.body.length).to.equal(1);
         expect(res.body[0].title).to.equal('newticket');
+        done();
+      })
+      .catch((err) => {
+        return done(err);
+      });
+  });
+
+  it('rejects PUT requests to /api/tickets to update ticket with assignee that isnt member of board', function(done) {
+    agent.get('/auth/fake3')
+      .then((res) => {
+        return agent.put('/api/tickets')
+          .send({
+            id: 3,
+            title: 'newticketname',
+            description: 'newticketname',
+            status: 'in progress',
+            priority: '1',
+            type: 'feature',
+            creator_id: 3,
+            assignee_handle: 'stevepkuo',
+            board_id: 3,
+            panel_id: 3
+          });
+      })
+      .then((res) => {
+        expect(res.status).to.equal(500);
+        return agent.get('/api/tickets')
+          .query({panel_id: 3});
+      })
+      .then((res) => {
+        expect(res.status).to.equal(200);
+        expect(res.body.length).to.equal(3);
         done();
       })
       .catch((err) => {


### PR DESCRIPTION
Add check that assignee_handle is member of board when creating or updating ticket.
Make tests more robust by only clearing the knex_migrations_lock table if it exists.